### PR TITLE
1.21に対応

### DIFF
--- a/src/Feature/CommandHelp/CommandHelpJava/index.tsx
+++ b/src/Feature/CommandHelp/CommandHelpJava/index.tsx
@@ -59,6 +59,8 @@ const CommandHelpJavaComponent = () => {
 
         <div className="text-xl font-semibold mt-8 mb-2"> Step4. {t.JAVA_COMMAND_SECTION4}</div>
         <div>{t.JAVA_COMMAND_TEXT4}</div>
+        <div className="text-xl font-semibold mt-8 mb-2"> Step5. {t.JAVA_COMMAND_SECTION5}</div>
+        <div>{t.JAVA_COMMAND_TEXT5}</div>
       </div>
     </>
   );

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -41,13 +41,16 @@ export default {
   JAVA_COMMAND_SECTION1: "Download commands.",
   JAVA_COMMAND_SECTION2: "Decompress the zip fiel.",
   JAVA_COMMAND_SECTION3: "Load commands from minecraft as datapack.",
-  JAVA_COMMAND_SECTION4: "Excute function.",
+  JAVA_COMMAND_SECTION4: "Change folder name（1.21 or later）",
+  JAVA_COMMAND_SECTION5: "Run command",
   JAVA_COMMAND_TEXT1: "Convert image in this app, and download zip file (minecraftDot.zip).",
   JAVA_COMMAND_TEXT2:
     "Decompress the zip file by clicking zip file You don't need special tools, just click file",
   JAVA_COMMAND_TEXT3:
     "Open ./minecraft/saves folder. There are world data folders. Open world folder that you excute command. In world folder, Open datapacks folder. Now you are supposed to open ./minecraft/saves/{world_name}/datapacks. In that folder, please put the folder (dot folder) that you get at step2.",
   JAVA_COMMAND_TEXT4:
+    "Rename from 'functions' to 'function'.",  
+  JAVA_COMMAND_TEXT5:
     "Enter the world and excute commmand like this, /function folderName:fileName folderName is the name of folder that includes functions folder. (dot_pack by default). fileName is the name of mcfunction file. (cmd by default) If the loading is successful, you will be presented with a list of possible commands while typing /function. When you edit commands, please excute /reload",
 
   // bedrock COMAMND

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -42,7 +42,7 @@ export default {
   JAVA_COMMAND_SECTION2: "Decompress the zip fiel.",
   JAVA_COMMAND_SECTION3: "Load commands from minecraft as datapack.",
   JAVA_COMMAND_SECTION4: "Change folder name（1.21 or later）",
-  JAVA_COMMAND_SECTION5: "Run command",
+  JAVA_COMMAND_SECTION5: "Execute function",
   JAVA_COMMAND_TEXT1: "Convert image in this app, and download zip file (minecraftDot.zip).",
   JAVA_COMMAND_TEXT2:
     "Decompress the zip file by clicking zip file You don't need special tools, just click file",

--- a/src/i18n/locales/ja.js
+++ b/src/i18n/locales/ja.js
@@ -41,13 +41,16 @@ export default {
   JAVA_COMMAND_SECTION1: "コマンドをダウンロードする",
   JAVA_COMMAND_SECTION2: "zipファイルを解凍",
   JAVA_COMMAND_SECTION3: "データパックとしてマインクラフトに読み込む",
-  JAVA_COMMAND_SECTION4: "コマンドを実行",
+  JAVA_COMMAND_SECTION4: "ファイル名を変更（1.21以降）",
+  JAVA_COMMAND_SECTION5: "コマンドを実行",
   JAVA_COMMAND_TEXT1: "本アプリで画像を変換し，zipファイル(minecraftDot.zip)をダウンロードしておきます．",
   JAVA_COMMAND_TEXT2:
     "zipファイルをクリックして解凍してください．特別なソフトは必要ありません．クリックするだけで大丈夫です．",
   JAVA_COMMAND_TEXT3:
     "./minecraft/savesフォルダを開きます．その中にワールド名のフォルダが並んでいると思うので，コマンドを使用したいワールドを開きます．さらにdatapacksフォルダを開きます．./minecraft/saves/ワールド名/datapacks フォルダを開いていればOKです．その中に先ほど解凍して得られたフォルダ(dotフォルダ)を入れます.",
   JAVA_COMMAND_TEXT4:
+    "functionsフォルダのフォルダ名から「s」を消して「function」に名前を変更します．",
+  JAVA_COMMAND_TEXT5:
     "最後にワールドに入りコマンドを入力します．/function フォルダ名:ファイル名と実行します．フォルダ名とはfunctionsフォルダが入っているフォルダ名です(デフォルトではdot_pack) ファイル名はfunctionsフォルダの中にあるmcfunctionファイルです(デフォルトではcmd)うまく読み込みが成功していれば，/functionを入力している段階でコマンドの候補が出てきます．コマンドに編集を行った場合，/reload を実行してください",
 
   // bedrock COMAMND


### PR DESCRIPTION
1.21で動かない問題に対処する文言を追加

1.21では、functionsフォルダの名称からsが削除され、functionという名前でしか動かないようになりました。
最新版で利用する人のためにJava版のコマンド実行方法のページ（[https://www.minecraft-dot.pictures/ja/command-help/java/](https://www.minecraft-dot.pictures/ja/command-help/java/)）に多少の文言を追加しました。